### PR TITLE
Received file overwrite protection

### DIFF
--- a/microservices/CFDP/app/models/cfdp_mib.rb
+++ b/microservices/CFDP/app/models/cfdp_mib.rb
@@ -256,20 +256,38 @@ class CfdpMib
     file.close
   end
 
-  def self.put_destination_file(destination_filename, tmp_file)
+  def self.put_destination_file(destination_filename, tmp_file, timestamp_format = "_%Y%m%d_%H%M%S")
     file_name = File.join(@@root_path, destination_filename)
+    actual_filename = destination_filename
+
     if self.bucket
-      OpenC3::Bucket.getClient().put_object(bucket: self.bucket, key: file_name, body: tmp_file.open.read)
+      client = OpenC3::Bucket.getClient()
+      if client.check_object(bucket: self.bucket, key: file_name)
+        # File exists, append timestamp to not overwrite it
+        timestamp = Time.now.utc.strftime(timestamp_format)
+        file_extension = File.extname(destination_filename)
+        base_name = File.basename(destination_filename, file_extension)
+        actual_filename = "#{base_name}#{timestamp}#{file_extension}"
+        file_name = File.join(@@root_path, actual_filename)
+      end
+      client.put_object(bucket: self.bucket, key: file_name, body: tmp_file.open.read)
     else
-      file_name = File.join(@@root_path, destination_filename)
+      if File.exist?(file_name)
+        # File exists, append timestamp to not overwrite it
+        timestamp = Time.now.utc.strftime(timestamp_format)
+        file_extension = File.extname(destination_filename)
+        base_name = File.basename(destination_filename, file_extension)
+        actual_filename = "#{base_name}#{timestamp}#{file_extension}"
+        file_name = File.join(@@root_path, actual_filename)
+      end
       tmp_file.persist(file_name)
     end
     tmp_file.unlink
-    return true
+    return true, actual_filename
   rescue => error
     OpenC3::Logger.error(error.message, scope: ENV['OPENC3_SCOPE'])
     # Something went wrong so return false
-    return false
+    return false, nil
   end
 
   def self.filestore_request(action_code, first_file_name, second_file_name)

--- a/plugin.txt
+++ b/plugin.txt
@@ -31,6 +31,9 @@ VARIABLE bucket config
 # Set to true to enable a test configuration
 VARIABLE plugin_test_mode "false"
 
+# Prevent files from being overwritten on receive by appending a timestamp to the new file if there's a name conflict
+VARIABLE prevent_received_file_overwrite "true"
+
 MICROSERVICE CFDP <%= cfdp_microservice_name %>
   WORK_DIR .
   ROUTE_PREFIX <%= cfdp_route_prefix %>
@@ -45,6 +48,7 @@ MICROSERVICE CFDP <%= cfdp_microservice_name %>
   OPTION destination_entity_id <%= destination_entity_id %>
   OPTION cmd_info <%= cfdp_cmd_target_name %> <%= cfdp_cmd_packet_name %> <%= cfdp_cmd_item_name %>
   OPTION root_path <%= root_path %>
+  OPTION prevent_received_file_overwrite <%= prevent_received_file_overwrite %>
   <% if bucket.to_s.strip != '' %>
     OPTION bucket <%= bucket %>
   <% end %>


### PR DESCRIPTION
Appends a timestamp to the filename when there's a conflict. Made this a plugin variable that defaults to enabled.